### PR TITLE
feat: add snacks plugin

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -36,6 +36,16 @@ require('lazy').setup({
     end,
   },
 
+  -- Snacks
+  {
+    'folke/snacks.nvim',
+    priority = 1000,
+    lazy = false,
+    config = function()
+      require('plugins.snacks_conf')
+    end,
+  },
+
   -- LSP
   {
     'mason-org/mason-lspconfig.nvim',

--- a/lua/plugins/snacks_conf.lua
+++ b/lua/plugins/snacks_conf.lua
@@ -1,0 +1,8 @@
+-- Snacks config
+require('snacks').setup({
+	bigfile = { enabled = true },
+	bufdelete = { enabled = true },
+	input = { enabled = true },
+	quickfile = { enabled = true },
+	scroll = { enabled = true },
+})


### PR DESCRIPTION
## Summary
- add snacks.nvim plugin with basic QoL modules

## Testing
- `nvim --headless --cmd "set rtp+=." -u ./init.lua '+q' 2>&1 | grep -n 'snacks_conf' -n` *(fails: module 'plugins.snacks_conf' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e62824e508320b970ab08e0ca2ddf